### PR TITLE
rpm: build noarch package

### DIFF
--- a/ceph-iscsi-tools.spec
+++ b/ceph-iscsi-tools.spec
@@ -7,6 +7,7 @@ License:	GPLv3
 
 URL:		https://github.com/pcuzner/ceph-iscsi-tools
 Source0:	https://github.com/pcuzner/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+BuildArch:      noarch
 
 BuildRequires: python2-devel
 BuildRequires: python-setuptools


### PR DESCRIPTION
Prior to this change, the RPM build process would generate an empty debuginfo package, because mock assumed the package was arch-specific.

Add the noarch label so that mock will not generate the empty ceph-iscsi-tools-debuginfo package, and we can use this package on more than just x86_64 eventually.
